### PR TITLE
Minor fixes for building with Clang

### DIFF
--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -118,7 +118,7 @@ class PkfsHookFile final : public HookFile {
         : HookFile(path, norm_path)
     {}
 
-    bool ramfs_demangle() {return false;};
+    bool ramfs_demangle() override {return false;};
 
     uint32_t call_real() override {
         log_if_modfile();

--- a/src/texbin.cpp
+++ b/src/texbin.cpp
@@ -423,7 +423,7 @@ bool Texbin::add_or_replace_image(const char *image_name, const char *png_path) 
 }
 
 void Texbin::debug() {
-    uint32_t total = 0;
+    [[maybe_unused]] uint32_t total = 0;
     for(auto &[name, image] : images) {
         [[maybe_unused]] auto [w,h] = image.peek_dimensions();
         VLOG("file: %s len %d fmt %s dims(%d,%d)",


### PR DESCRIPTION
Two small changes for building with an LLVM-based toolchain.

```
FAILED: ifs_hook.dll.p/src_hook.cpp.obj
"x86_64-w64-mingw32-clang++" "-Iifs_hook.dll.p" "-I." "-I.." "-fdiagnostics-color=always" "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST" "-D_FILE_OFFSET_BITS=64" "-Wall" "-Winvalid-pch" "-Werror" "-std=c++20" "-O3" "-DVER_STRING=\"3
.9\"" -MD -MQ ifs_hook.dll.p/src_hook.cpp.obj -MF "ifs_hook.dll.p\src_hook.cpp.obj.d" -o ifs_hook.dll.p/src_hook.cpp.obj "-c" ../src/hook.cpp
../src/hook.cpp:121:10: error: 'ramfs_demangle' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  121 |     bool ramfs_demangle() {return false;};
      |          ^
../src/hook.h:68:18: note: overridden virtual function is here
   68 |     virtual bool ramfs_demangle() {return false;};
      |                  ^
1 error generated.
[2/4] Compiling C++ object libtexbin.a.p/src_texbin.cpp.obj
FAILED: libtexbin.a.p/src_texbin.cpp.obj
"x86_64-w64-mingw32-clang++" "-Ilibtexbin.a.p" "-I." "-I.." "-fdiagnostics-color=always" "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST" "-D_FILE_OFFSET_BITS=64" "-Wall" "-Winvalid-pch" "-Werror" "-std=c++20" "-O3" "-DVER_STRING=\"3.
9\"" -MD -MQ libtexbin.a.p/src_texbin.cpp.obj -MF "libtexbin.a.p\src_texbin.cpp.obj.d" -o libtexbin.a.p/src_texbin.cpp.obj "-c" ../src/texbin.cpp
../src/texbin.cpp:426:14: error: variable 'total' set but not used [-Werror,-Wunused-but-set-variable]
  426 |     uint32_t total = 0;
      |              ^
1 error generated.
```